### PR TITLE
Fix wrong image save directory

### DIFF
--- a/CameraClassTemplate.any
+++ b/CameraClassTemplate.any
@@ -74,8 +74,9 @@ VIDEO_INPUT_SCALE = 1    # The ratio between video resolution and input images s
   ) 
 {
   
+  
   /// The output path where the video is saved 
-  #var AnyFileVar OutputPath = _CAMERA_MAIN_FILE_DIRECTORY_;
+  #var AnyStringVar OutputPath = _CAMERA_MAIN_FILE_DIRECTORY_;
   
   /// The point the camera focus on
   #var AnyVec3 LookAtPoint = DesignVar({0,1,0});
@@ -106,7 +107,7 @@ VIDEO_INPUT_SCALE = 1    # The ratio between video resolution and input images s
     
   AnyOperationSequence Preview =  
   {
-    AnyFileVar preview_file = FilePathRelativeOf(.OutputPath) +"/" + VIDEO_NAME + "_Camera_Preview.png";  
+    AnyFileVar preview_file = .OutputPath +"/" + VIDEO_NAME + "_Camera_Preview.png";  
     AnyOperationSetValue SetFilename= 
     {
       Source = {&.preview_file}; 
@@ -189,7 +190,7 @@ VIDEO_INPUT_SCALE = 1    # The ratio between video resolution and input images s
     AnyCamRecorder Recorder = {  
       AnyStringVar F = "Hack- Do not delete";
       
-      FileName = FilePathRelativeOf(..OutputPath) + "/"+ VIDEO_NAME + "_" + strval(..Counter ,COUNTER_FORMAT )+ "." + IMAGE_EXT;
+      FileName = ..OutputPath + "/"+ VIDEO_NAME + "_" + strval(..Counter ,COUNTER_FORMAT )+ "." + IMAGE_EXT;
       #var pxWidth = round(WIDTH * VIDEO_INPUT_SCALE*1.0);
       #var pxHeight = round(HEIGHT * VIDEO_INPUT_SCALE*1.0);
       #var Trig = DesignVar(Off);
@@ -225,7 +226,7 @@ VIDEO_INPUT_SCALE = 1    # The ratio between video resolution and input images s
         #var FileName = "cmd.exe";
         #var AnyStringVar inputfile =  VIDEO_NAME + "_" + COUNTER_FORMAT  +"." + IMAGE_EXT;
         
-        #var AnyFileVar out_file = FilePathRelativeOf(...OutputPath) + "/"+ VIDEO_NAME + ".mp4";
+        #var AnyFileVar out_file = ...OutputPath + "/"+ VIDEO_NAME + ".mp4";
         
         
         #var AnyFileVar ffmpegpath = FFMPEG_PATH; 
@@ -249,7 +250,7 @@ VIDEO_INPUT_SCALE = 1    # The ratio between video resolution and input images s
         " -metadata author="+strquote("AnyBodyTechnology")+" " +
         strquote(FilePathCompleteOf(out_file));
         
-        #var WorkDir = FilePathCompleteOf(...OutputPath);
+        #var WorkDir = ...OutputPath;
         #var Show = _DEBUG;
       };  
       AnyOperationSequence RemoveImageFiles = 
@@ -265,7 +266,7 @@ VIDEO_INPUT_SCALE = 1    # The ratio between video resolution and input images s
           #var FileName = "cmd.exe";
           #var  Arguments = CmdOpt + "del " + strquote(VIDEO_NAME + "_" + "*." + IMAGE_EXT);
           
-          #var WorkDir = FilePathCompleteOf(....OutputPath) ;
+          #var WorkDir = ....OutputPath;
           #var Show = _DEBUG;
           Wait = _DEBUG;
         };   

--- a/ExampleModel.any
+++ b/ExampleModel.any
@@ -6,7 +6,7 @@
 Main = {
 
   // This is a simple example of using the camera class to create videos.
-  VideoLookAtCamera MyCam (UP_DIRECTION = y, SKIP_FRAMES = 7) = 
+  VideoLookAtCamera MyCam (UP_DIRECTION = y) = 
   {
        // The point the camera focus on  
        LookAtPoint = Main.MyModel.Femur.Knee.r + {0, -0.1, 0};  
@@ -24,6 +24,11 @@ Main = {
        // Determines the speed of the video. Setting it to 
        // nStep/(tEnd-tStart) will make the video run in real time. 
        InputFrameRate = 10;
+       
+       // Override the default camera counter with the time step from the study.
+       // This ensures that we only save the images from the analysis. 
+       Counter = Main.MyStudy.iStep;
+       
        
        // The operations which should be included in the video.
        Analysis = {

--- a/ExampleModelHuman.any
+++ b/ExampleModelHuman.any
@@ -21,18 +21,18 @@ Main = {
     
     // Override the default camera counter with the time step from the study.
     // This ensures that we only save the images from the analysis. 
-    Counter = Main.MyStudy.iStep;
+    Counter = Main.Study.iStep;
     
     // The sequence of analysis to make the recording from.
     Analysis = {
-      AnyOperation &ref = Main.MyStudy.Kinematics;
+      AnyOperation &ref = Main.Study.Kinematics;
     };
   };
   
   // Include the HumanModel from the repository
   #include "<ANYBODY_PATH_BODY>/HumanModel.any"
 
-  AnyBodyStudy MyStudy = {
+  AnyBodyStudy Study = {
      AnyFolder &model = .HumanModel.BodyModelWithDefaultDrivers;
      Gravity = {0.0, -9.81, 0.0};
 


### PR DESCRIPTION
Fix issue where images were saved to the wrong path.  …

This issue occurs when the class template is included from a file in a subfolder. This would cause the camera recorder to save the images in the subfolder instead of the directory of the main file.

